### PR TITLE
Add `figlet` command line interface

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+var figlet = require('../lib/node-figlet');
+
+var optimist = require('optimist')
+    .usage('Usage: $0 "text to print"')
+    .alias('h', 'help')
+    .alias('v', 'version')
+    .alias('l', 'list')
+    .describe('l', 'List all the available fonts')
+    .alias('f', 'font')
+    .describe('f', 'A string value that indicates the FIGlet font to use')
+    .describe('horizontal-layout', 'A string value that indicates the horizontal layout to use')
+    .describe('vertical-layout', 'A string value that indicates the vertical layout to use');
+
+var argv = optimist.argv;
+var text = argv._.join(' ');
+var options = {};
+
+if (argv.version) {
+    return console.log(require('../package.json').version);
+}
+
+if (argv.list) {
+    figlet.fonts(function(err, fonts) {
+        if (err) {
+          console.log('something went wrong...');
+          console.dir(err);
+          return;
+        }
+        fonts.forEach(function(font) {
+            console.log(font);
+        });
+    });
+    return;
+}
+
+if (!text || argv.help) {
+    return console.log(optimist.help());
+}
+
+if (argv.font) options.font = argv.font
+if (argv['horizontal-layout']) options.horizontalLayout = argv['horizontal-layout']
+if (argv['vertical-layout']) options.verticalLayout = argv['vertical-layout']
+
+figlet(text, options, function(err, data) {
+    if (err) {
+        console.log('Something went wrong...');
+        console.dir(err);
+        return;
+    }
+    console.log(data);
+});

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
         "url": "http://www.opensource.org/licenses/MIT" 
     } ],
     "main": "./lib/node-figlet.js",
+    "bin": {
+        "figlet": "bin/cmd.js"
+    },
     "dependencies": {
-        
+        "optimist": "~0.6.0"
     },
     "devDependencies": {
         


### PR DESCRIPTION
I thought it would be cool to have a command line interface to figlet. What do you think?

Use `npm link` to globally symlink the `figlet` command. Otherwise you'll need to use `node bin/cmd.js`

```
$ npm link
$ figlet -f Rectangles "Pull Request?"
                                              _____
 _____     _ _    _____                     _|___  |
|  _  |_ _| | |  | __  |___ ___ _ _ ___ ___| |_|  _|
|   __| | | | |  |    -| -_| . | | | -_|_ -|  _|_|
|__|  |___|_|_|  |__|__|___|_  |___|___|___|_| |_|
                             |_|
```
