### PR TITLE
Update figlet.js

### DIFF
--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -881,6 +881,7 @@ var figlet = figlet || (function() {
 
         jQuery.ajax({
             url: figDefaults.fontPath + '/' + fontName + '.flf',
+            dataType: 'text',
             success: function(data) {
                 var options = me.parseFont(fontName, data);
                 next(null, options);


### PR DESCRIPTION
Added dataType:'text' to jQuery.ajax

Without this parameter, Firefox 26 would not load the FIG font and raises an error about XML parsing.
That occured while working locally (on file:// instead of http://)

Adding the proper dataType to the ajax call solved the problem.
