### PR TITLE
Update license attribuet

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
         "email": "patorjk@gmail.com",
         "url": "http://patorjk.com/"
     },
-    "licenses": [ {
-        "type": "MIT",
-        "url": "http://www.opensource.org/licenses/MIT" 
-    } ],
+    "license": "MIT",
     "main": "./lib/node-figlet.js",
     "dependencies": {
 


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/