### PR TITLE
Allow bowser synchronous figlet generation for already loaded fonts

### DIFF
--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -3,7 +3,7 @@
     By Patrick Gillespie (patorjk@gmail.com)
     Originally Written For: http://patorjk.com/software/taag/
     License: MIT (with this header staying intact)
-    
+
     This JavaScript code aims to fully implement the FIGlet spec.
     Full FIGlet spec: http://patorjk.com/software/taag/docs/figfont.txt
 
@@ -31,14 +31,14 @@ var figlet = figlet || (function() {
         FITTING = 1,
         SMUSHING = 2,
         CONTROLLED_SMUSHING = 3;
-    
+
     // ---------------------------------------------------------------------
     // Variable that will hold information about the fonts
 
     var figFonts = {}; // What stores all of the FIGlet font data
     var figDefaults = {
         font: 'Standard',
-        fontPath: './fonts' 
+        fontPath: './fonts'
     };
 
     // ---------------------------------------------------------------------
@@ -54,7 +54,7 @@ var figlet = figlet || (function() {
         var codes = [[16384,"vLayout",SMUSHING], [8192,"vLayout",FITTING], [4096, "vRule5", true], [2048, "vRule4", true],
                      [1024, "vRule3", true], [512, "vRule2", true], [256, "vRule1", true], [128, "hLayout", SMUSHING],
                      [64, "hLayout", FITTING], [32, "hRule6", true], [16, "hRule5", true], [8, "hRule4", true], [4, "hRule3", true],
-                     [2, "hRule2", true], [1, "hRule1", true]]; 
+                     [2, "hRule2", true], [1, "hRule1", true]];
 
         val = (newLayout !== null) ? newLayout : oldLayout;
         index = 0;
@@ -87,7 +87,7 @@ var figlet = figlet || (function() {
                 rules["hLayout"] = CONTROLLED_SMUSHING;
             }
         }
-        
+
         if (typeof rules["vLayout"] === "undefined") {
             if (rules["vRule1"] || rules["vRule2"] || rules["vRule3"] || rules["vRule4"] ||rules["vRule5"]  ) {
                 rules["vLayout"] = CONTROLLED_SMUSHING;
@@ -99,8 +99,8 @@ var figlet = figlet || (function() {
                 rules["vLayout"] = CONTROLLED_SMUSHING;
             }
         }
-        
-        return rules;   
+
+        return rules;
     }
 
     /* The [vh]Rule[1-6]_Smush functions return the smushed character OR false if the two characters can't be smushed */
@@ -132,7 +132,7 @@ var figlet = figlet || (function() {
         }
         return false;
     }
-    
+
     /*
         Rule 3: HIERARCHY SMUSHING (code value 4)
 
@@ -205,7 +205,7 @@ var figlet = figlet || (function() {
         }
         return false;
     }
-    
+
     /*
         Rule 1: EQUAL CHARACTER SMUSHING (code value 256)
 
@@ -215,7 +215,7 @@ var figlet = figlet || (function() {
         if (ch1 === ch2) {return ch1;}
         return false;
     }
-    
+
     /*
         Rule 2: UNDERSCORE SMUSHING (code value 512)
 
@@ -247,7 +247,7 @@ var figlet = figlet || (function() {
         }
         return false;
     }
-    
+
     /*
         Rule 4: HORIZONTAL LINE SMUSHING (code value 2048)
 
@@ -264,7 +264,7 @@ var figlet = figlet || (function() {
         }
         return false;
     }
-    
+
     /*
         Rule 5: VERTICAL LINE SUPERSMUSHING (code value 4096)
 
@@ -285,7 +285,7 @@ var figlet = figlet || (function() {
         }
         return false;
     }
-    
+
     /*
         Universal smushing simply overrides the sub-character from the
         earlier FIGcharacter with the sub-character from the later
@@ -295,7 +295,7 @@ var figlet = figlet || (function() {
     */
     function uni_Smush(ch1, ch2, hardBlank) {
         if (ch2 === " " || ch2 === "") {
-            return ch1;   
+            return ch1;
         } else if (ch2 === hardBlank && ch1 !== " ") {
             return ch1;
         } else {
@@ -310,7 +310,7 @@ var figlet = figlet || (function() {
         txt1 - A line of text
         txt2 - A line of text
         opts - FIGlet options array
-        
+
         About: Takes in two lines of text and returns one of the following:
         "valid" - These lines can be smushed together given the current smushing rules
         "end" - The lines can be smushed, but we're at a stopping point
@@ -321,7 +321,7 @@ var figlet = figlet || (function() {
         var ii, len = Math.min(txt1.length, txt2.length);
         var ch1, ch2, endSmush = false, validSmush;
         if (len===0) {return "invalid";}
-        
+
         for (ii = 0; ii < len; ii++) {
             ch1 = txt1.substr(ii,1);
             ch2 = txt2.substr(ii,1);
@@ -343,7 +343,7 @@ var figlet = figlet || (function() {
             }
         }
         if (endSmush) {
-            return "end";   
+            return "end";
         } else {
             return "valid";
         }
@@ -357,10 +357,10 @@ var figlet = figlet || (function() {
         var curDist = 1;
         var ii, ret, result;
         while (curDist <= maxDist) {
-            
+
             subLines1 = lines1.slice(Math.max(0,len1-curDist), len1);
             subLines2 = lines2.slice(0, Math.min(maxDist, curDist));
-            
+
             slen = subLines2.length;//TODO:check this
             result = "";
             for (ii = 0; ii < slen; ii++) {
@@ -376,19 +376,19 @@ var figlet = figlet || (function() {
                     }
                 }
             }
-            
+
             if (result === "invalid") {curDist--;break;}
             if (result === "end") {break;}
             if (result === "valid") {curDist++;}
         }
-        
+
         return Math.min(maxDist,curDist);
     }
 
     function verticallySmushLines(line1, line2, opts) {
         var ii, len = Math.min(line1.length, line2.length);
         var ch1, ch2, result = "", validSmush;
-        
+
         for (ii = 0; ii < len; ii++) {
             ch1 = line1.substr(ii,1);
             ch2 = line2.substr(ii,1);
@@ -419,7 +419,7 @@ var figlet = figlet || (function() {
         var piece2_1 = lines1.slice(Math.max(0,len1-overlap), len1);
         var piece2_2 = lines2.slice(0, Math.min(overlap, len2));
         var ii, len, line, piece2 = [], piece3, result = [];
-        
+
         len = piece2_1.length;
         for (ii = 0; ii < len; ii++) {
             if (ii >= len2) {
@@ -429,19 +429,19 @@ var figlet = figlet || (function() {
             }
             piece2.push(line);
         }
-        
+
         piece3 = lines2.slice(Math.min(overlap,len2), len2);
-        
+
         return result.concat(piece1,piece2,piece3);
     }
 
     function padLines(lines, numSpaces) {
         var ii, len = lines.length, padding = "";
         for (ii = 0; ii < numSpaces; ii++) {
-            padding += " ";   
+            padding += " ";
         }
         for (ii = 0; ii < len; ii++) {
-            lines[ii] += padding;   
+            lines[ii] += padding;
         }
     }
 
@@ -470,7 +470,7 @@ var figlet = figlet || (function() {
         var validSmush = false;
         var seg1, seg2, ch1, ch2;
         if (len1 === 0) {return 0;}
-        
+
         distCal: while (curDist <= maxDist) {
             seg1 = txt1.substr(len1-curDist,curDist);
             seg2 = txt2.substr(0,Math.min(curDist,len2));
@@ -489,14 +489,14 @@ var figlet = figlet || (function() {
                     } else {
                         breakAfter = true; // we know we need to break, but we need to check if our smushing rules will allow us to smush the overlapped characters
                         validSmush = false; // the below checks will let us know if we can smush these characters
-                        
+
                         validSmush = (opts.fittingRules.hRule1) ? hRule1_Smush(ch1,ch2,opts.hardBlank) : validSmush;
                         validSmush = (!validSmush && opts.fittingRules.hRule2) ? hRule2_Smush(ch1,ch2,opts.hardBlank) : validSmush;
                         validSmush = (!validSmush && opts.fittingRules.hRule3) ? hRule3_Smush(ch1,ch2,opts.hardBlank) : validSmush;
                         validSmush = (!validSmush && opts.fittingRules.hRule4) ? hRule4_Smush(ch1,ch2,opts.hardBlank) : validSmush;
                         validSmush = (!validSmush && opts.fittingRules.hRule5) ? hRule5_Smush(ch1,ch2,opts.hardBlank) : validSmush;
                         validSmush = (!validSmush && opts.fittingRules.hRule6) ? hRule6_Smush(ch1,ch2,opts.hardBlank) : validSmush;
-                        
+
                         if (!validSmush) {
                             curDist = curDist - 1;
                             break distCal;
@@ -513,7 +513,7 @@ var figlet = figlet || (function() {
     function horizontalSmush(textBlock1, textBlock2, overlap, opts) {
         var ii, jj, ch, outputFig = [],
             overlapStart,piece1,piece2,piece3,len1,len2,txt1,txt2;
-            
+
         for (ii = 0; ii < opts.height; ii++) {
             txt1 = textBlock1[ii];
             txt2 = textBlock2[ii];
@@ -522,15 +522,15 @@ var figlet = figlet || (function() {
             overlapStart = len1-overlap;
             piece1 = txt1.substr(0,Math.max(0,overlapStart));
             piece2 = "";
-            
+
             // determine overlap piece
             var seg1 = txt1.substr(Math.max(0,len1-overlap),overlap);
             var seg2 = txt2.substr(0,Math.min(overlap,len2));
-            
+
             for (jj = 0; jj < overlap; jj++) {
                 var ch1 = (jj < len1) ? seg1.substr(jj,1) : " ";
                 var ch2 = (jj < len2) ? seg2.substr(jj,1) : " ";
-                
+
                 if (ch1 !== " " && ch2 !== " ") {
                     if (opts.fittingRules.hLayout === FITTING) {
                         piece2 += uni_Smush(ch1, ch2, opts.hardBlank);
@@ -594,7 +594,7 @@ var figlet = figlet || (function() {
         }
         return outputFigText;
     }
-    
+
     // -------------------------------------------------------------------------
     // Parsing and Generation methods
 
@@ -603,7 +603,7 @@ var figlet = figlet || (function() {
             params = {}, prop, ii;
         if (layout === "default") {
             for (ii = 0; ii < props.length; ii++) {
-                params[props[ii]] = options.fittingRules[props[ii]];   
+                params[props[ii]] = options.fittingRules[props[ii]];
             }
         } else if (layout === "full") {
             params = {"hLayout": FULL_WIDTH,"hRule1":false,"hRule2":false,"hRule3":false,"hRule4":false,"hRule5":false,"hRule6":false};
@@ -614,7 +614,7 @@ var figlet = figlet || (function() {
         } else if (layout === "universal smushing") {
             params = {"hLayout": SMUSHING,"hRule1":false,"hRule2":false,"hRule3":false,"hRule4":false,"hRule5":false,"hRule6":false};
         } else {
-            return;   
+            return;
         }
         return params;
     };
@@ -624,7 +624,7 @@ var figlet = figlet || (function() {
             params = {}, prop, ii;
         if (layout === "default") {
             for (ii = 0; ii < props.length; ii++) {
-                params[props[ii]] = options.fittingRules[props[ii]];   
+                params[props[ii]] = options.fittingRules[props[ii]];
             }
         } else if (layout === "full") {
             params = {"vLayout": FULL_WIDTH,"vRule1":false,"vRule2":false,"vRule3":false,"vRule4":false,"vRule5":false};
@@ -635,7 +635,7 @@ var figlet = figlet || (function() {
         } else if (layout === "universal smushing") {
             params = {"vLayout": SMUSHING,"vRule1":false,"vRule2":false,"vRule3":false,"vRule4":false,"vRule5":false};
         } else {
-            return;   
+            return;
         }
         return params;
     };
@@ -660,7 +660,7 @@ var figlet = figlet || (function() {
         for (ii = 1; ii < len; ii++) {
             output = smushVerticalFigLines(output, figLines[ii], options);
         }
-        
+
         return output.join("\n");
     };
 
@@ -793,7 +793,7 @@ var figlet = figlet || (function() {
                 next(err);
                 return;
             }
-            
+
             next(null, fontOpts, figFonts[fontName].comment);
         });
     };
@@ -820,7 +820,7 @@ var figlet = figlet || (function() {
     me.parseFont = function(fontName, data) {
         data = data.replace(/\r\n/g,"\n").replace(/\r/g,"\n");
         figFonts[fontName] = {};
-        
+
         var lines = data.split("\n");
         var headerData = lines.splice(0,1)[0].split(" ");
         var figFont = figFonts[fontName];
@@ -834,7 +834,7 @@ var figlet = figlet || (function() {
         opts.numCommentLines = parseInt(headerData[5], 10);
         opts.printDirection = (headerData.length >= 6) ? parseInt(headerData[6], 10) : 0;
         opts.fullLayout = (headerData.length >= 7) ? parseInt(headerData[7], 10) : null;
-        opts.codeTagCount = (headerData.length >= 8) ? parseInt(headerData[8], 10) : null;            
+        opts.codeTagCount = (headerData.length >= 8) ? parseInt(headerData[8], 10) : null;
         opts.fittingRules = getSmushingRules(opts.oldLayout, opts.fullLayout);
 
         figFont.options = opts;
@@ -845,18 +845,18 @@ var figlet = figlet || (function() {
             isNaN(opts.baseline) ||
             isNaN(opts.maxLength) ||
             isNaN(opts.oldLayout) ||
-            isNaN(opts.numCommentLines) ) 
+            isNaN(opts.numCommentLines) )
         {
             throw new Error('FIGlet header contains invalid values.');
         }
-        
+
         /*
             All FIGlet fonts must contain chars 32-126, 196, 214, 220, 228, 246, 252, 223
         */
 
         var charNums = [], ii;
         for (ii = 32; ii <= 126; ii++) {
-            charNums.push(ii);   
+            charNums.push(ii);
         }
         charNums = charNums.concat(196, 214, 220, 228, 246, 252, 223);
 
@@ -864,7 +864,7 @@ var figlet = figlet || (function() {
         if (lines.length < (opts.numCommentLines + (opts.height * charNums.length)) ) {
             throw new Error('FIGlet file is missing data.');
         }
-        
+
         /*
             Parse out the context of the file and put it into our figFont object
         */
@@ -873,7 +873,7 @@ var figlet = figlet || (function() {
 
         figFont.comment = lines.splice(0,opts.numCommentLines).join("\n");
         figFont.numChars = 0;
-        
+
         while (lines.length > 0 && figFont.numChars < charNums.length) {
             cNum = charNums[figFont.numChars];
             figFont[cNum] = lines.splice(0,opts.height);
@@ -888,8 +888,8 @@ var figlet = figlet || (function() {
             }
             figFont.numChars++;
         }
-        
-        /* 
+
+        /*
             Now we check to see if any additional characters are present
         */
 
@@ -910,7 +910,7 @@ var figlet = figlet || (function() {
                 parseError = true;
                 break;
             }
-            
+
             figFont[cNum] = lines.splice(0,opts.height);
             // remove end sub-chars
             for (ii = 0; ii < opts.height; ii++) {
@@ -928,12 +928,12 @@ var figlet = figlet || (function() {
         if (parseError === true) {
             throw new Error('Error parsing data.');
         }
-        
+
         return opts;
     };
 
     /*
-        Loads a font. 
+        Loads a font.
     */
     me.loadFont = function(fontName, next) {
         if (figFonts[fontName]) {
@@ -965,6 +965,9 @@ var figlet = figlet || (function() {
         loads a font synchronously, not implemented for the browser
      */
     me.loadFontSync = function(name) {
+        if (figFonts[name]) {
+          return figFonts[name].options;
+        }
         throw new Error('synchronous font loading is not implemented for the browser');
     };
 


### PR DESCRIPTION
One could preload the fonts required prior to using the `textSync` function, here's an working example,

```
  var fontName = "Standard"
  var fontPath = 'node_modules/figlet/fonts'

  figlet.defaults({fontPath: fontPath});

  function onload(){
    console.log(figlet.textSync("It works"));
  }

  jQuery.ajax({
    url: fontPath + '/' + fontName + '.flf',
    dataType: 'text',
    success: function(data) {
        try {
            figlet.parseFont(fontName, data);
            onload();
        } catch(error) { /* do something */ }
    },
    error: function() {/* do something else */}
  });
```
Thanks, 