### PR TITLE
Adding support to preload fonts

### DIFF
--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -971,6 +971,28 @@ var figlet = figlet || (function() {
         throw new Error('synchronous font loading is not implemented for the browser');
     };
 
+    /*
+        preloads a list of fonts prior to using textSync
+        - fonts: an array of font names (i.e. ["Standard","Soft"])
+        - next: callback function
+     */
+    me.preloadFonts = function(fonts, next) {
+
+      if (typeof jQuery === 'undefined') { /* TODO: create common function for jQuery checks */
+          throw new Error('jQuery is required for ajax method to work.');
+      }
+
+      jQuery.when.apply(this, fonts.map(function(name){
+            return jQuery.get(figDefaults.fontPath + '/' + name + '.flf')
+          })).then(function() {
+                      var args = fonts.length > 1 ? arguments : [arguments];
+                      for(var i in fonts){
+                        me.parseFont(fonts[i], args[i][0]);
+                      }
+                      if(next)next();
+          });
+    };
+
     return me;
 })();
 


### PR DESCRIPTION
A working example 

```
figlet.defaults({fontPath: "node_modules/figlet/fonts"});

figlet.preloadFonts(["Standard","Soft","Jacky"], function(){
  console.log(figlet.textSync("It works .. "));
  console.log(figlet.textSync("No :/ ", "Jacky"));
  console.log(figlet.textSync("Yes :)", "Soft"));
});
```

Result, 

```
  ___ _                        _        
 |_ _| |_  __      _____  _ __| | _____ 
  | || __| \ \ /\ / / _ \| '__| |/ / __|
  | || |_   \ V  V / (_) | |  |   <\__ \
 |___|\__|   \_/\_/ \___/|_|  |_|\_\___/
                                        
     __      _     ____                  _  
   /  \    / )   / __ \       __       / ) 
  / /\ \  / /   / /  \ \     (__)     / /  
  ) ) ) ) ) )  ( ()  () )            / /   
 ( ( ( ( ( (   ( ()  () )           / /    
 / /  \ \/ /    \ \__/ /      __   / /     
(_/    \__/      \____/      (__) (_/      
                                           
,--.   ,--.                    ,-.   
 \  `.'  /,---.  ,---.     .--.'. \  
  '.    /| .-. :(  .-'     '--' |  | 
    |  | \   --..-'  `)    .--. |  | 
    `--'  `----'`----'     '--'.' /  
                               `-'   
```