### PR TITLE
Replace jQuery requirement with fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,12 @@ console.log(figlet.fontsSync());
 Getting Started - The Browser
 -------------------------
 
-The browser API is the same as the Node API with the exception of the "fonts" method not being available. The browser version also requires jQuery (any version should work as it only utilizes the ajax method for its loadFont function).
+The browser API is the same as the Node API with the exception of the "fonts" method not being available. The browser version also requires [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (or a [shim](https://github.com/github/fetch)) for its loadFont function.
 
 Example usage:
 
 ```html
-<script type="text/javascript" src="jquery-1.7.2.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
 <script type="text/javascript" src="figlet.js"></script>
 
 <script>

--- a/examples/front-end/index.htm
+++ b/examples/front-end/index.htm
@@ -55,7 +55,9 @@
     
 <script>
 
-if (window.location.protocol === 'file:) alert('fetch APi does not support file: protocol.');
+if (window.location.protocol === 'file:') {
+    alert('fetch APi does not support file: protocol.');
+}
     
 figlet.defaults({
     fontPath: '../../fonts'

--- a/examples/front-end/index.htm
+++ b/examples/front-end/index.htm
@@ -55,7 +55,7 @@
     
 <script>
 
-if ()
+if (window.location.protocol === 'file:) alert('fetch APi does not support file: protocol.');
     
 figlet.defaults({
     fontPath: '../../fonts'

--- a/examples/front-end/index.htm
+++ b/examples/front-end/index.htm
@@ -49,6 +49,7 @@
     </div>
     <div id="outputFigDisplay"></div>
     
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
     <script type="text/javascript" src="jquery-1.7.2.min.js"></script>
     <script type="text/javascript" src="../../lib/figlet.js"></script>
     

--- a/examples/front-end/index.htm
+++ b/examples/front-end/index.htm
@@ -49,12 +49,14 @@
     </div>
     <div id="outputFigDisplay"></div>
     
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
-    <script type="text/javascript" src="jquery-1.7.2.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script type="text/javascript" src="../../lib/figlet.js"></script>
     
 <script>
 
+if ()
+    
 figlet.defaults({
     fontPath: '../../fonts'
 });

--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -948,7 +948,7 @@ var figlet = figlet || (function() {
                 throw new Error('Network response was not ok.');
             })
             .then(function(text) {
-                next(null, me.parseFont(fontName, data);
+                next(null, me.parseFont(fontName, data));
             })
             .catch(next);
     };

--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -14,16 +14,8 @@
 
 "use strict";
 
-/*
-    For front-end work, the jQuery library should be included before figlet.js.
-    Since jQuery is used in the ajax method, we define jQuery here so we can
-    throw an error later if its undefined and so things checkout with jshint.
-    As a side note, Node overwrites the method that uses jQuery.
-*/
-var jQuery;
-
 var figlet = figlet || (function() {
-
+    
     // ---------------------------------------------------------------------
     // Private static variables
 
@@ -941,24 +933,24 @@ var figlet = figlet || (function() {
             return;
         }
 
-        if (typeof jQuery === 'undefined') {
-            throw new Error('jQuery is required for ajax method to work.');
+        if (typeof fetch !== 'function') {
+          console.error('figlet.js requires the fetch API or a fetch polyfill such as https://cdnjs.com/libraries/fetch');
+          throw new Error('fetch is required for figlet.js to work.')
         }
 
-        jQuery.ajax({
-            url: figDefaults.fontPath + '/' + fontName + '.flf',
-            dataType: 'text',
-            success: function(data) {
-                try {
-                    next(null, me.parseFont(fontName, data));
-                } catch(error) {
-                    next(error);
+        fetch(figDefaults.fontPath + '/' + fontName + '.flf')
+            .then(function(response) {
+                if(response.ok) {
+                    return response.text();
                 }
-            },
-            error: function() {
-                next(arguments);
-            }
-        });
+            
+                console.log('Unexpected response', response);
+                throw new Error('Network response was not ok.');
+            })
+            .then(function(text) {
+                next(null, me.parseFont(fontName, data);
+            })
+            .catch(next);
     };
 
     /*


### PR DESCRIPTION
Remove huge jquery requirement in favor of fetch API, available in most browsers[0], shim available elsewhere[1].

[0] http://caniuse.com/#feat=fetch
[1] https://github.com/github/fetch
[2] https://cdnjs.com/libraries/fetch