### PR TITLE
Allow loading fonts in node

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ figlet -f "Dancing Font" "Hi"
 For more info see the [figlet-cli](https://github.com/patorjk/figlet-cli).
 
 ## Release History
+* 2018.03.26 v1.2.1 parseFont works in node for adding fonts manually
 * 2016.09.27 v1.2.0 jQuery replaced with fetch API / polyfill.
 * 2016.04.28 v1.1.2 textSync now works in the browser with font pre-loading.
 * 2013.01.02 v1.0.8 Added tests and command line info.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ The synchronous version of the fonts method
 console.log(figlet.fontsSync());
 ```
 
+### parseFont
+
+Allows you to use a font from another source.
+
+```js
+const fs = require('fs');
+const path = require('path');
+
+let data = fs.readFileSync(path.join(__dirname, 'myfont.flf'), 'utf8');
+figlet.parseFont('myfont', data);
+console.log(figlet.textSync('myfont!', 'myfont'));
+```
+
 Getting Started - The Browser
 -------------------------
 

--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -985,6 +985,8 @@ var figlet = figlet || (function() {
           });
     };
 
+    me.figFonts = figFonts;
+    
     return me;
 })();
 

--- a/lib/node-figlet.js
+++ b/lib/node-figlet.js
@@ -14,6 +14,11 @@ var figlet = require('./figlet.js'),
     - next (function): Callback function.
 */
 figlet.loadFont = function(name, next) {
+    if (figlet.figFonts[name]) {
+        next(null, figlet.figFonts[name].options);
+        return;
+    }
+
     fs.readFile(fontDir + name + '.flf',  {encoding: 'utf-8'}, function(err, fontData) {
         if (err) {
             return next(err);
@@ -35,6 +40,10 @@ figlet.loadFont = function(name, next) {
  - name (string): Name of the font to load.
  */
 figlet.loadFontSync = function(name) {
+    if (figlet.figFonts[name]) {
+        return figlet.figFonts[name].options;
+    }
+
     var fontData = fs.readFileSync(fontDir + name + '.flf',  {encoding: 'utf-8'});
 
     fontData = fontData + '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "figlet",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Creates ASCII Art from text. A full implementation of the FIGfont spec.",
     "keywords": ["figlet", "ascii", "art", "banner", "ansi"],
     "repository": {

--- a/test/expected/.gitattributes
+++ b/test/expected/.gitattributes
@@ -1,0 +1,3 @@
+# these files are always checked out with lf only, required
+# for tests to pass on windows
+* text eol=lf

--- a/test/figlet_test.js
+++ b/test/figlet_test.js
@@ -5,6 +5,7 @@
 var figlet = require('../lib/node-figlet'),
     grunt = require('grunt'),
     fs = require('fs'),
+    path = require('path'),
     async = require('async');
 
 /*
@@ -52,6 +53,18 @@ exports.figlet = {
         var actual = figlet.textSync('FIGlet\nFONTS', {font: 'Standard', verticalLayout: 'fitted'});
 
         test.equal(actual, expected, 'Standard font with a vertical layout of "fitted".');
+
+        test.done();
+    },
+    standardParse: function(test) {
+        test.expect(1);
+
+        var expected = grunt.file.read('test/expected/standard');
+        var data = fs.readFileSync(path.join(__dirname, '../fonts/Standard.flf'), 'utf8');
+        var font = figlet.parseFont('StandardParseFontName', data);
+        var actual = figlet.textSync('FIGlet\nFONTS', {font: 'StandardParseFontName', verticalLayout: 'fitted'});
+
+        test.equal(actual, expected, 'Standard font with a vertical layout of "fitted" loaded using parseFont().');
 
         test.done();
     },


### PR DESCRIPTION
* had to add figFonts[] to normal figlet object for access
  in the node version
* node figlet object checks if a font exists already when
  loading instead of loading it every time like base does
* expected directory has .gitattributes file so files are
  always checked out with LF so tests pass on Windows

This lets you use a font from a source other than the included fonts.

I think the node version was loading and parsing the font each time text was generated instead of using the version in `figFonts` if it was already loaded.  This change lets you use the `parseFont` method to load a font from the font definition as a string and not get an error because the font file couldn't be read when `loadFile` or `loadFileSync` was called in `text` or `textSync`.