### PR TITLE
async text

### DIFF
--- a/examples/node/app.js
+++ b/examples/node/app.js
@@ -20,6 +20,14 @@ var figlet = require("../../lib/node-figlet.js");
   const example2 = await figlet.text("Async Example", "Graffiti");
   console.log(example2);
 
+  const example3 = await figlet.text("Bonus Example.", {
+    font: "Standard",
+    horizontalLayout: "full",
+    verticalLayout: "full",
+  });
+
+  console.log(example3);
+
   figlet("Callback World!", "Standard", function (err, data) {
     if (err) {
       console.log("Something went wrong...");

--- a/examples/node/app.js
+++ b/examples/node/app.js
@@ -13,16 +13,14 @@ var figlet = require("../../lib/node-figlet.js");
 */
 // var figlet = require('figlet');
 
-figlet("Hello World!", "Standard", function (err, data) {
-  if (err) {
-    console.log("Something went wrong...");
-    console.dir(err);
-    return;
-  }
+(async () => {
+  const helloWorld = await figlet("Async World!", "Standard");
+  console.log(helloWorld);
 
-  console.log(data);
+  const example2 = await figlet.text("Async Example", "Graffiti");
+  console.log(example2);
 
-  figlet.text("Again, Hello World!", "Graffiti", function (err, data) {
+  figlet("Callback World!", "Standard", function (err, data) {
     if (err) {
       console.log("Something went wrong...");
       console.dir(err);
@@ -31,21 +29,14 @@ figlet("Hello World!", "Standard", function (err, data) {
 
     console.log(data);
 
-    figlet.text(
-      "Last time...",
-      {
-        font: "Standard",
-        horizontalLayout: "full",
-        verticalLayout: "full",
-      },
-      function (err, data) {
-        if (err) {
-          console.log("Something went wrong...");
-          console.dir(err);
-          return;
-        }
-        console.log(data);
+    figlet.text("Callback Example", "Graffiti", function (err, data) {
+      if (err) {
+        console.log("Something went wrong...");
+        console.dir(err);
+        return;
       }
-    );
+
+      console.log(data);
+    });
   });
-});
+})();

--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -1143,7 +1143,7 @@ const figlet = (() => {
         - next (function): A callback function, it will contained the outputted ASCII Art.
     */
   const me = function (txt, options, next) {
-    me.text(txt, options, next);
+    return me.text(txt, options, next);
   };
   me.text = async function (txt, options, next) {
     let fontName = "";
@@ -1173,9 +1173,8 @@ const figlet = (() => {
       */
       me.loadFont(fontName, function (err, fontOpts) {
         if (err) {
-          console.log("Finished 2 ");
           reject(err);
-          next(err);
+          if (next) next(err);
           return;
         }
 
@@ -1185,9 +1184,8 @@ const figlet = (() => {
           txt
         );
 
-        console.log("Finished");
         resolve(generatedTxt);
-        next(null, generatedTxt);
+        if (next) next(null, generatedTxt);
       });
     });
   };

--- a/lib/figlet.js
+++ b/lib/figlet.js
@@ -1145,7 +1145,7 @@ const figlet = (() => {
   const me = function (txt, options, next) {
     me.text(txt, options, next);
   };
-  me.text = function (txt, options, next) {
+  me.text = async function (txt, options, next) {
     let fontName = "";
 
     // Validate inputs
@@ -1165,20 +1165,30 @@ const figlet = (() => {
       fontName = options.font || figDefaults.font;
     }
 
-    /*
-            Load the font. If it loads, it's data will be contained in the figFonts object.
-            The callback will recieve a fontsOpts object, which contains the default
-            options of the font (its fitting rules, etc etc).
-        */
-    me.loadFont(fontName, function (err, fontOpts) {
-      if (err) {
-        return next(err);
-      }
+    return await new Promise((resolve, reject) => {
+      /*
+          Load the font. If it loads, it's data will be contained in the figFonts object.
+          The callback will recieve a fontsOpts object, which contains the default
+          options of the font (its fitting rules, etc etc).
+      */
+      me.loadFont(fontName, function (err, fontOpts) {
+        if (err) {
+          console.log("Finished 2 ");
+          reject(err);
+          next(err);
+          return;
+        }
 
-      next(
-        null,
-        generateText(fontName, _reworkFontOpts(fontOpts, options), txt)
-      );
+        const generatedTxt = generateText(
+          fontName,
+          _reworkFontOpts(fontOpts, options),
+          txt
+        );
+
+        console.log("Finished");
+        resolve(generatedTxt);
+        next(null, generatedTxt);
+      });
     });
   };
 

--- a/test/figlet_test.js
+++ b/test/figlet_test.js
@@ -52,6 +52,23 @@ exports.figlet = {
       }
     );
   },
+  standardAsync: async function (test) {
+    test.expect(1);
+
+    const result = await figlet("FIGlet\nFONTS", {
+      font: "Standard",
+      verticalLayout: "fitted",
+    });
+
+    var expected = grunt.file.read("test/expected/standard");
+    test.equal(
+      result,
+      expected,
+      'Standard font with a vertical layout of "fitted".'
+    );
+
+    test.done();
+  },
   standardSync: function (test) {
     test.expect(1);
 


### PR DESCRIPTION
Both figlet and figlet.text now support promises and async/await syntax instead of old callbacks ( that no one almost uses today )

Example of how to use it:
```
import figlet from figlet

(async()=>{
      const a = await figlet.text("Hello World", "Standard")
      console.log(a)
})()
```