### PR TITLE
Fix for commonjs import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Thanks goes to these people: ([emoji key](https://allcontributors.org/docs/en/em
 
 ## Release History
 
+- 2026.07.13 v1.11.2 Fix for CommonJS import issue 
 - 2026.07.11 v1.11.1 Added TypeScript autocomplete enhancement for font names (https://github.com/patorjk/figlet.js/pull/155), thanks to @harshtalks
 - 2026.03.08 v1.11.0 Added Future Thin and Future Smooth fonts.
 - 2025.12.25 v1.10.0 Renamed "ANSI-Compact" to "ANSI Compact" (with backward compatibility). Added the fonts: Classy, Coder Mini, and Font Font. Fixed the "U" characters in the "Isometric 4" font. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "figlet",
-  "version": "1.11.1",
+  "version": "1.11.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "figlet",
-      "version": "1.11.1",
+      "version": "1.11.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figlet",
-  "version": "1.11.1",
+  "version": "1.11.2-beta.0",
   "description": "Creates ASCII Art from text. A full implementation of the FIGfont spec.",
   "keywords": [
     "figlet",

--- a/package.json
+++ b/package.json
@@ -94,9 +94,10 @@
   "scripts": {
     "pre-build-scripts": "node utils/create-font-list.js && node utils/flf-to-strings.js",
     "prebuild": "npm run pre-build-scripts",
-    "build": "vite build && npm run commonJSFixes",
+    "build": "vite build && npm run commonJSFixes && npm run smoke-test-dist",
     "dev": "vite build --watch",
     "test": "vitest run",
+    "smoke-test-dist": "node utils/smoke-test-dist.js",
     "commonJSFixes": "node utils/copy-cjs-types.js",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/src/node-figlet.ts
+++ b/src/node-figlet.ts
@@ -17,10 +17,15 @@ import {
 } from "./figlet-types";
 import { getFontName } from "./renamed-fonts.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+// In the CJS bundle the bundler replaces `import.meta` with `{}`, so
+// `import.meta.url` is only usable in the ESM build; CJS falls back to
+// the real __dirname global (our local must not shadow it).
+const moduleDirname: string =
+  typeof __dirname !== "undefined"
+    ? __dirname
+    : path.dirname(fileURLToPath(import.meta.url));
 
-const fontPath: string = path.join(__dirname, "/../fonts/");
+const fontPath: string = path.join(moduleDirname, "/../fonts/");
 
 // Type assertion for the figlet module
 const nodeFiglet = figlet as FigletModule;

--- a/utils/smoke-test-dist.js
+++ b/utils/smoke-test-dist.js
@@ -1,0 +1,37 @@
+/*
+  Smoke test for the built bundles in dist/. The unit tests run against
+  src/, so packaging breaks (e.g. import.meta.url being mis-transpiled
+  in the CJS output, as in issue with figlet 1.11.1) only show up when
+  the built files are actually loaded. Run after every build.
+*/
+import assert from 'assert';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const require = createRequire(import.meta.url);
+const distDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../dist',
+);
+
+// CommonJS build: requiring it must not throw, and font path resolution
+// must work so a default-font render succeeds.
+const figletCjs = require(path.join(distDir, 'node-figlet.cjs'));
+const cjsOutput = figletCjs.textSync('ok');
+assert.ok(
+  typeof cjsOutput === 'string' && cjsOutput.trim().length > 0,
+  'node-figlet.cjs: textSync produced no output',
+);
+
+// ESM build
+const figletEsm = (
+  await import(pathToFileURL(path.join(distDir, 'node-figlet.mjs')).href)
+).default;
+const esmOutput = figletEsm.textSync('ok');
+assert.ok(
+  typeof esmOutput === 'string' && esmOutput.trim().length > 0,
+  'node-figlet.mjs: textSync produced no output',
+);
+
+console.log('dist smoke test passed (node-figlet.cjs, node-figlet.mjs)');


### PR DESCRIPTION
When upgrading vite, it changed how `import.meta.url` was processed in CJS output, it previously was a shim, so this pattern used to work. Vite 8 is rolldown-based, and rolldown just replaces `import.meta` with an empty object literal, thus producing the error.

Added a smoke test to prevent anything like this in the future.