### PR TITLE
Bug fix for invalid values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "async": "~3.2.4",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.5",
+        "prettier": "^3.9.5",
         "typescript": "^5.9.2",
         "vite": "^8.1.4",
         "vite-plugin-dts": "^4.5.4",
@@ -2233,6 +2234,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/quansync": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "async": "~3.2.4",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "prettier": "^3.9.5",
     "typescript": "^5.9.2",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^4.5.4",

--- a/src/figlet.ts
+++ b/src/figlet.ts
@@ -806,8 +806,7 @@ const figlet: FigletModule = (() => {
     }
     // No break point fits within opts.width, which happens when a single
     // character is wider than the requested width. Emit the first character
-    // on its own line so the caller always makes forward progress; otherwise
-    // the while-loop in generateFigTextLines would spin forever.
+    // on its own line.
     if (figChars.length > 0) {
       return {
         outputFigText: joinFigArray([figChars[0]], len, opts),

--- a/src/figlet.ts
+++ b/src/figlet.ts
@@ -804,6 +804,16 @@ const figlet: FigletModule = (() => {
         };
       }
     }
+    // No break point fits within opts.width, which happens when a single
+    // character is wider than the requested width. Emit the first character
+    // on its own line so the caller always makes forward progress; otherwise
+    // the while-loop in generateFigTextLines would spin forever.
+    if (figChars.length > 0) {
+      return {
+        outputFigText: joinFigArray([figChars[0]], len, opts),
+        chars: figChars.slice(1),
+      };
+    }
     return { outputFigText: newFigChar(len), chars: figChars };
   }
 
@@ -1192,9 +1202,7 @@ const figlet: FigletModule = (() => {
   const me = async function (
     txt: string,
     optionsOrFontOrCallback?:
-      | FigletOptions
-      | FontName
-      | CallbackFunction<string>,
+      FigletOptions | FontName | CallbackFunction<string>,
     callback?: CallbackFunction<string>,
   ): Promise<string> {
     return me.text(txt, optionsOrFontOrCallback, callback);
@@ -1202,9 +1210,7 @@ const figlet: FigletModule = (() => {
   me.text = async function (
     txt: string,
     optionsOrFontOrCallback?:
-      | FigletOptions
-      | FontName
-      | CallbackFunction<string>,
+      FigletOptions | FontName | CallbackFunction<string>,
     callback?: CallbackFunction<string>,
   ): Promise<string> {
     txt = txt + ""; // ensure string
@@ -1385,6 +1391,17 @@ const figlet: FigletModule = (() => {
     }
 
     if (opts.height == null || opts.numCommentLines == null) {
+      throw new Error("FIGlet header contains invalid values.");
+    }
+
+    // Counts and dimensions must not be negative, and the font must have at
+    // least one row.
+    if (
+      opts.height < 1 ||
+      opts.baseline! < 0 ||
+      opts.maxLength! < 0 ||
+      opts.numCommentLines < 0
+    ) {
       throw new Error("FIGlet header contains invalid values.");
     }
 

--- a/test/node-figlet.test.ts
+++ b/test/node-figlet.test.ts
@@ -151,6 +151,39 @@ describe('node-figlet', () => {
       const expected = readExpected('wrapWhitespaceLogString');
       expect(actual).toBe(expected);
     });
+
+    it('should terminate when width is smaller than a single character (word break)', async () => {
+      const actual = await figlet.text("AB", {
+        font: "Standard",
+        width: 1,
+        whitespaceBreak: true,
+      });
+
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBeGreaterThan(0);
+    });
+
+    it('should terminate for single-character input when width is smaller than a character', async () => {
+      const actual = await figlet.text("A", {
+        font: "Standard",
+        width: 1,
+        whitespaceBreak: true,
+      });
+
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBeGreaterThan(0);
+    });
+
+    it('should terminate for multi-word input when width is smaller than a character', async () => {
+      const actual = await figlet.text("hi there world", {
+        font: "Standard",
+        width: 1,
+        whitespaceBreak: true,
+      });
+
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBeGreaterThan(0);
+    });
   });
 
 
@@ -237,6 +270,27 @@ describe('node-figlet', () => {
       } catch (err: any) {
         expect(err?.message).toContain('Font');
       }
+    });
+
+    it('should reject a font header with a negative height', () => {
+      expect(() =>
+        figlet.parseFont("NegHeightFont", "flf2a$ -2 -2 8 -1 0\n"),
+      ).toThrow("FIGlet header contains invalid values.");
+      expect(figlet.loadedFonts()).not.toContain("NegHeightFont");
+    });
+
+    it('should reject a font header with a zero height', () => {
+      expect(() =>
+        figlet.parseFont("ZeroHeightFont", "flf2a$ 0 0 8 -1 0\n"),
+      ).toThrow("FIGlet header contains invalid values.");
+      expect(figlet.loadedFonts()).not.toContain("ZeroHeightFont");
+    });
+
+    it('should reject a font header with a negative comment-line count', () => {
+      expect(() =>
+        figlet.parseFont("NegCommentFont", "flf2a$ 8 6 8 -1 -3\n"),
+      ).toThrow("FIGlet header contains invalid values.");
+      expect(figlet.loadedFonts()).not.toContain("NegCommentFont");
     });
   });
 


### PR DESCRIPTION
Some extra bug handling code + prettier as as dev dep. With whitespaceBreak: true and a set width: 1 character, it was possible for the library to get into an infinite loop if the text given was large. Also fixed a case of invalid header data that could cause a similar issue (this would only happen if someone created their own font, not for any of the provided fonts).